### PR TITLE
Adds partnerParameters on track calls

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
@@ -12,6 +12,7 @@ import com.adjust.sdk.OnAttributionChangedListener;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
 import com.segment.analytics.ValueMap;
+import com.segment.analytics.integrations.BasePayload;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
@@ -84,24 +85,27 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
     adjust.onCreate(adjustConfig);
   }
 
+  private void setPartnerParams(BasePayload payload) {
+    String userId = payload.userId();
+    if (!isNullOrEmpty(userId)) {
+      adjust.addSessionPartnerParameter("userId", userId);
+      logger.verbose("adjust.addSessionPartnerParameter(userId, %s)", userId);
+    }
+
+    String anonymousId = payload.anonymousId();
+    if (!isNullOrEmpty(anonymousId)) {
+      adjust.addSessionPartnerParameter("anonymousId", anonymousId);
+      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, %s)", anonymousId);
+    }
+  }
+
   @Override public AdjustInstance getUnderlyingInstance() {
     return adjust;
   }
 
   @Override public void identify(IdentifyPayload identify) {
     super.identify(identify);
-
-    String userId = identify.userId();
-    if (!isNullOrEmpty(userId)) {
-      adjust.addSessionPartnerParameter("userId", userId);
-      logger.verbose("adjust.addSessionPartnerParameter(userId, %s)", userId);
-    }
-
-    String anonymousId = identify.anonymousId();
-    if (!isNullOrEmpty(anonymousId)) {
-      adjust.addSessionPartnerParameter("anonymousId", anonymousId);
-      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, %s)", anonymousId);
-    }
+    setPartnerParams(identify);
   }
 
   @Override public void reset() {
@@ -112,18 +116,7 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
 
   @Override public void track(TrackPayload track) {
     super.track(track);
-
-    String userId = track.userId();
-    if (!isNullOrEmpty(userId)) {
-      adjust.addSessionPartnerParameter("userId", userId);
-      logger.verbose("adjust.addSessionPartnerParameter(userId, %s)", userId);
-    }
-
-    String anonymousId = track.anonymousId();
-    if (!isNullOrEmpty(anonymousId)) {
-      adjust.addSessionPartnerParameter("anonymousId", anonymousId);
-      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, %s)", anonymousId);
-    }
+    setPartnerParams(track);
 
     String token = customEvents.getString(track.event());
     if (isNullOrEmpty(token)) {

--- a/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
@@ -92,15 +92,15 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
     super.identify(identify);
 
     String userId = identify.userId();
-    if (userId != null) {
+    if (!isNullOrEmpty(userId)) {
       adjust.addSessionPartnerParameter("userId", userId);
-      logger.verbose("adjust.addSessionPartnerParameter(userId, (%s))", userId);
+      logger.verbose("adjust.addSessionPartnerParameter(userId, %s)", userId);
     }
 
     String anonymousId = identify.anonymousId();
-    if (anonymousId != null) {
+    if (!isNullOrEmpty(anonymousId)) {
       adjust.addSessionPartnerParameter("anonymousId", anonymousId);
-      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, (%s))", anonymousId);
+      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, %s)", anonymousId);
     }
   }
 
@@ -114,15 +114,15 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
     super.track(track);
 
     String userId = track.userId();
-    if (userId != null) {
+    if (!isNullOrEmpty(userId)) {
       adjust.addSessionPartnerParameter("userId", userId);
-      logger.verbose("adjust.addSessionPartnerParameter(userId, (%s))", userId);
+      logger.verbose("adjust.addSessionPartnerParameter(userId, %s)", userId);
     }
 
     String anonymousId = track.anonymousId();
-    if (anonymousId != null) {
+    if (!isNullOrEmpty(anonymousId)) {
       adjust.addSessionPartnerParameter("anonymousId", anonymousId);
-      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, (%s))", anonymousId);
+      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, %s)", anonymousId);
     }
 
     String token = customEvents.getString(track.event());

--- a/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
@@ -113,6 +113,18 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
   @Override public void track(TrackPayload track) {
     super.track(track);
 
+    String userId = track.userId();
+    if (userId != null) {
+      adjust.addSessionPartnerParameter("userId", userId);
+      logger.verbose("adjust.addSessionPartnerParameter(userId, (%s))", userId);
+    }
+
+    String anonymousId = track.anonymousId();
+    if (anonymousId != null) {
+      adjust.addSessionPartnerParameter("anonymousId", anonymousId);
+      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, (%s))", anonymousId);
+    }
+
     String token = customEvents.getString(track.event());
     if (isNullOrEmpty(token)) {
       return;
@@ -128,7 +140,6 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
     if (revenue != 0 && !isNullOrEmpty(currency)) {
       event.setRevenue(revenue, currency);
     }
-
     logger.verbose("Adjust.getDefaultInstance().trackEvent(%s);", event);
     adjust.trackEvent(event);
   }

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -165,14 +165,15 @@ public class AdjustIntegrationTest {
     PowerMockito.whenNew(AdjustEvent.class).withArguments("bar").thenReturn(event);
 
     Traits traits = createTraits() //
-        .putValue("anonymousId", "1234");
+        .putValue("anonymousId", "123");
 
-    integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
     integration.track(new TrackPayloadBuilder()
         .event("foo")
+        .traits(traits)
         .build());
+
     verify(adjustInstance).trackEvent(event);
-    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "1234");
+    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "123");
 
   }
 
@@ -180,33 +181,32 @@ public class AdjustIntegrationTest {
     AdjustEvent event = mock(AdjustEvent.class);
     PowerMockito.whenNew(AdjustEvent.class).withArguments("bar").thenReturn(event);
 
-    Traits traits = createTraits() //
-        .putValue("userId", "5678");
+    Traits traits = createTraits("123");
 
-    integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
     integration.track(new TrackPayloadBuilder()
         .event("foo")
+        .traits(traits)
         .build());
     verify(adjustInstance).trackEvent(event);
-    verify(adjustInstance).addSessionPartnerParameter("userId", "5678");
+    verify(adjustInstance).addSessionPartnerParameter("userId", "123");
 
   }
 
-  @Test public void trackWithBoth() throws Exception {
+  @Test public void trackWithUserIdAndAnonymousId() throws Exception {
     AdjustEvent event = mock(AdjustEvent.class);
     PowerMockito.whenNew(AdjustEvent.class).withArguments("bar").thenReturn(event);
 
-    Traits traits = createTraits() //
-        .putValue("anonymousId", "1234") //
-        .putValue("userId", "5678");
+    Traits traits = createTraits("123") //
+        .putValue("anonymousId", "789");
 
-    integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
     integration.track(new TrackPayloadBuilder()
         .event("foo")
+        .traits(traits)
         .build());
+
     verify(adjustInstance).trackEvent(event);
-    verify(adjustInstance).addSessionPartnerParameter("userId", "5678");
-    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "1234");
+    verify(adjustInstance).addSessionPartnerParameter("userId", "123");
+    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "789");
   }
 
   @Test public void trackWithoutMatchingCustomEventDoesNothing() throws Exception {

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -160,6 +160,22 @@ public class AdjustIntegrationTest {
     verify(adjustInstance).trackEvent(event);
   }
 
+  @Test public void trackWithAnonymousId() throws Exception {
+    AdjustEvent event = mock(AdjustEvent.class);
+    PowerMockito.whenNew(AdjustEvent.class).withArguments("bar").thenReturn(event);
+
+    Traits traits = createTraits() //
+        .putValue("anonymousId", "1234");
+
+    integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
+    integration.track(new TrackPayloadBuilder()
+        .event("foo")
+        .build());
+    verify(adjustInstance).trackEvent(event);
+    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "1234");
+
+  }
+
   @Test public void trackWithoutMatchingCustomEventDoesNothing() throws Exception {
     integration.track(new TrackPayloadBuilder().event("bar").build());
     verify(adjustInstance, never()).trackEvent(any(AdjustEvent.class));

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -176,6 +176,39 @@ public class AdjustIntegrationTest {
 
   }
 
+  @Test public void trackWithUserId() throws Exception {
+    AdjustEvent event = mock(AdjustEvent.class);
+    PowerMockito.whenNew(AdjustEvent.class).withArguments("bar").thenReturn(event);
+
+    Traits traits = createTraits() //
+        .putValue("userId", "5678");
+
+    integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
+    integration.track(new TrackPayloadBuilder()
+        .event("foo")
+        .build());
+    verify(adjustInstance).trackEvent(event);
+    verify(adjustInstance).addSessionPartnerParameter("userId", "5678");
+
+  }
+
+  @Test public void trackWithBoth() throws Exception {
+    AdjustEvent event = mock(AdjustEvent.class);
+    PowerMockito.whenNew(AdjustEvent.class).withArguments("bar").thenReturn(event);
+
+    Traits traits = createTraits() //
+        .putValue("anonymousId", "1234") //
+        .putValue("userId", "5678");
+
+    integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
+    integration.track(new TrackPayloadBuilder()
+        .event("foo")
+        .build());
+    verify(adjustInstance).trackEvent(event);
+    verify(adjustInstance).addSessionPartnerParameter("userId", "5678");
+    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "1234");
+  }
+
   @Test public void trackWithoutMatchingCustomEventDoesNothing() throws Exception {
     integration.track(new TrackPayloadBuilder().event("bar").build());
     verify(adjustInstance, never()).trackEvent(any(AdjustEvent.class));


### PR DESCRIPTION
#This  sets Segment's userId and anonymousId if present in Adjust. It is crucial that either the `anonymousId` or `userId` is set as soon as possible (ex. on `Application Opened`) so that Adjust sends back the `Install Attributed` event with one of the two Segment required fields. 

The current state of the integration does not set this value on `track`, so the `Install Attributed` is being dropped by Segment. 

For surfline, JIRA ticket [here](https://segment.atlassian.net/browse/PLATFORM-1210)