### PR TITLE
Bump adjust SDK to 4.15.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.1.5'
 
-  compile 'com.adjust.sdk:adjust-android:4.11.4'
+  compile 'com.adjust.sdk:adjust-android:4.15.1'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.3.2') {


### PR DESCRIPTION
JIRA: [GA-585](https://segment.atlassian.net/secure/RapidBoard.jspa?rapidView=120&modal=detail&selectedIssue=GA-585)
CC Ticket:[ CC-2192](https://segment.atlassian.net/secure/RapidBoard.jspa?rapidView=130&modal=detail&selectedIssue=CC-2192&assignee=raj)

This PR bumps the Adjust SDK to v4.15.1 which is the latest version of the SDK. The change was requested by a BT customer (Doordash). The latest Adjust SDK release includes functionality for GDPR. Our previous integration was using v4.11 which was released in September 2017. 

End to end testing was performed using a test android application and ensuring data was flowing properly both to Segment and to Adjust with no errors. An outline of the E2E testing, with screenshots or both dashboards can be found here: 
https://paper.dropbox.com/doc/Adjust-Android-SDK-Bump-E2E-Testing--AQkkSVfHd0xRilwFM7rixhtpAg-pkM96z4VlilG8g197uXb0