### PR TITLE
Update user/anonymous id in partner params to match our iOS library and adjusts docs

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
@@ -88,14 +88,14 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
   private void setPartnerParams(BasePayload payload) {
     String userId = payload.userId();
     if (!isNullOrEmpty(userId)) {
-      adjust.addSessionPartnerParameter("userId", userId);
-      logger.verbose("adjust.addSessionPartnerParameter(userId, %s)", userId);
+      adjust.addSessionPartnerParameter("user_id", userId);
+      logger.verbose("adjust.addSessionPartnerParameter(user_id, %s)", userId);
     }
 
     String anonymousId = payload.anonymousId();
     if (!isNullOrEmpty(anonymousId)) {
-      adjust.addSessionPartnerParameter("anonymousId", anonymousId);
-      logger.verbose("adjust.addSessionPartnerParameter(anonymousId, %s)", anonymousId);
+      adjust.addSessionPartnerParameter("anonymous_id", anonymousId);
+      logger.verbose("adjust.addSessionPartnerParameter(anonymous_id, %s)", anonymousId);
     }
   }
 

--- a/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adjust/AdjustIntegrationTest.java
@@ -121,7 +121,7 @@ public class AdjustIntegrationTest {
 
     integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
 
-    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "1234");
+    verify(adjustInstance).addSessionPartnerParameter("anonymous_id", "1234");
   }
 
   @Test public void identifyWithUserId() {
@@ -131,7 +131,7 @@ public class AdjustIntegrationTest {
 
     integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
 
-    verify(adjustInstance).addSessionPartnerParameter("userId", "34235");
+    verify(adjustInstance).addSessionPartnerParameter("user_id", "34235");
   }
 
   @Test public void identifyWithBoth() {
@@ -142,8 +142,8 @@ public class AdjustIntegrationTest {
 
     integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
 
-    verify(adjustInstance).addSessionPartnerParameter("userId", "34235");
-    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "123");
+    verify(adjustInstance).addSessionPartnerParameter("user_id", "34235");
+    verify(adjustInstance).addSessionPartnerParameter("anonymous_id", "123");
 
   }
 
@@ -173,7 +173,7 @@ public class AdjustIntegrationTest {
         .build());
 
     verify(adjustInstance).trackEvent(event);
-    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "123");
+    verify(adjustInstance).addSessionPartnerParameter("anonymous_id", "123");
 
   }
 
@@ -188,7 +188,7 @@ public class AdjustIntegrationTest {
         .traits(traits)
         .build());
     verify(adjustInstance).trackEvent(event);
-    verify(adjustInstance).addSessionPartnerParameter("userId", "123");
+    verify(adjustInstance).addSessionPartnerParameter("user_id", "123");
 
   }
 
@@ -205,8 +205,8 @@ public class AdjustIntegrationTest {
         .build());
 
     verify(adjustInstance).trackEvent(event);
-    verify(adjustInstance).addSessionPartnerParameter("userId", "123");
-    verify(adjustInstance).addSessionPartnerParameter("anonymousId", "789");
+    verify(adjustInstance).addSessionPartnerParameter("user_id", "123");
+    verify(adjustInstance).addSessionPartnerParameter("anonymous_id", "789");
   }
 
   @Test public void trackWithoutMatchingCustomEventDoesNothing() throws Exception {


### PR DESCRIPTION
Changing the parameter name for anonymousId and userId for the partner session parmas we send to Amplitude.

This will being this in line with our iOS integration https://github.com/segment-integrations/analytics-ios-integration-adjust/blob/b89d2635b42e0886ebae29512af398be8bd3deef/Pod/Classes/SEGAdjustIntegration.m#L103

and adjust's docs: https://docs.adjust.com/en/special-partners/segment/