### PR TITLE
fix(setup): attribution not fired on first app open after install

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adjust/AdjustIntegration.java
@@ -83,6 +83,7 @@ public class AdjustIntegration extends Integration<AdjustInstance> {
         break;
     }
     adjust.onCreate(adjustConfig);
+    adjust.onResume();
   }
 
   private void setPartnerParams(BasePayload payload) {


### PR DESCRIPTION
There's an issue where 'Install Attributed' is fired only after the app has been backgrounded and re-opened after install. 

The reason was because it was missing the onResume() call after setting up adjustConfig to immediately trigger the check for attribution.