### PR TITLE
chore: adjust SDK updated to 4.31.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
   compileOnly 'com.segment.analytics.android:analytics:4.10.0'
 
-  api 'com.adjust.sdk:adjust-android:4.29.1'
+  api 'com.adjust.sdk:adjust-android:4.31.1'
 
   testImplementation 'junit:junit:4.12'
   testImplementation('org.robolectric:robolectric:3.3.2') {


### PR DESCRIPTION
I have updated the Adjust SDK dependency in order to support the `com.google.android.gms.permission.AD_ID`

Ref: https://github.com/adjust/android_sdk/releases/tag/v4.31.1