### PR TITLE
Update segment.analytics.android to 4.10.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     google()
   }
 
-  compileOnly 'com.segment.analytics.android:analytics:4.10.0'
+  compileOnly 'com.segment.analytics.android:analytics:4.10.4'
 
   api 'com.adjust.sdk:adjust-android:4.29.1'
 


### PR DESCRIPTION
Fix for https://github.com/segment-integrations/analytics-android-integration-adjust/issues/20 via https://github.com/segmentio/analytics-android/issues/801
Should remove warning for Google Play publishing 